### PR TITLE
Fix SOS Light blinking issue (#57)

### DIFF
--- a/DPVController/ledLamp.cpp
+++ b/DPVController/ledLamp.cpp
@@ -36,7 +36,8 @@ void setLEDState(int state);
 
 void turnLampOn(){setLEDState(LAMP_MAX);}
 void turnLampOff(){
-  setLEDState(LED_State);//Use previous
+  // Always turn lamp fully off when stopping a blink (e.g., SOS sequence)
+  setLEDState(LAMP_OFF);
 }
 
 Blinker lampBlinker = Blinker(turnLampOn, turnLampOff);


### PR DESCRIPTION
Ensure that after the SOS blink sequence completes, the lamp is always turned off regardless of its previous state. This prevents the light from staying on permanently when at 100% brightness.

Closes #57