### PR TITLE
Restore LED state after blink sequence (#48)

### DIFF
--- a/.vscode/arduino.json
+++ b/.vscode/arduino.json
@@ -4,5 +4,5 @@
     "programmer": "esptool",
     "sketch": "DPVController\\DPVController.ino",
     "output": "build-output",
-    "port": "COM6"
+    "port": "COM4"
 }

--- a/DPVController/ledLamp.cpp
+++ b/DPVController/ledLamp.cpp
@@ -31,6 +31,9 @@ const int LAMP_BLINK_PAUSE = 400;                        // ms pause between lam
 static int preBlinkLEDState = LAMP_OFF;
 static bool shouldRestoreLED = false;
 static unsigned long blinkRestoreTime = 0;
+static bool isFlashing = false;
+static int flashStep = 0;
+static unsigned long flashStepTime = 0;
 int LED_State = LAMP_OFF;
 int lastStandbyBlinkTime = 0; //The timestamp(ms) when we last blinked for standby-warning.
 
@@ -47,7 +50,9 @@ void turnLampOff() {
 Blinker lampBlinker = Blinker(turnLampOn, turnLampOff);
 
 long lampDuration(char c){
-  return (c == '1') ? 200 : 600;
+  if (c == '1') return 200;      // Short blink
+  if (c == 'F') return 1000;     // Flash
+  return 600;                    // Long blink or pause
 }
 
 BlinkSequence lampSequence = BlinkSequence(lampBlinker, lampDuration, LAMP_BLINK_PAUSE);
@@ -62,7 +67,36 @@ void ledLampSetup(){
 void ledLampLoop(){
   lampSequence.loop();
   lampBlinker.loop();
-  // Restore LED state after blink sequence
+  
+  // Handle flash sequence
+  if (isFlashing && millis() >= flashStepTime) {
+    switch (flashStep) {
+      case 1: // Step 1: Turn off for 1 second
+        setLEDState(LAMP_OFF);
+        flashStepTime = millis() + 1000;
+        flashStep = 2;
+        break;
+      case 2: // Step 2: Flash on max for 1 second  
+        setLEDState(LAMP_MAX);
+        flashStepTime = millis() + 1000;
+        flashStep = 3;
+        break;
+      case 3: // Step 3: Turn off for 1 second
+        setLEDState(LAMP_OFF);
+        flashStepTime = millis() + 1000;
+        flashStep = 4;
+        break;
+      case 4: // Step 4: Restore original state
+        LED_State = preBlinkLEDState;
+        setLEDState(LED_State);
+        setBarLED(LED_State);
+        isFlashing = false;
+        flashStep = 0;
+        break;
+    }
+  }
+  
+  // Restore LED state after blink sequence (for SOS etc.)
   if (shouldRestoreLED && millis() >= blinkRestoreTime) {
     // Restore previous state and update LED and bar
     LED_State = preBlinkLEDState;
@@ -73,14 +107,12 @@ void ledLampLoop(){
 }
 
 void flash(){
-  // If LED was on before flashing, save state and turn off
-  if (LED_State != LAMP_OFF) {
-    preBlinkLEDState = LED_State;
-    shouldRestoreLED = true;
-    blinkRestoreTime = millis() + 1000; // 1000ms flash duration
-    turnLampOff();
+  if (!isFlashing) { // Only start flash if not already flashing
+    preBlinkLEDState = LED_State;  // Save current state
+    isFlashing = true;
+    flashStep = 1;
+    flashStepTime = millis(); // Start immediately
   }
-  lampBlinker.blink(1000);
 }
 
 void toggleLED(){

--- a/DPVController/ledLamp.cpp
+++ b/DPVController/ledLamp.cpp
@@ -23,10 +23,14 @@ const int LAMP_OFF = 0;
 const int LAMP_MAX = 4;
 const int StandbyBlinkStart = 15 * 60/*s*/ * 1000 * 1000;         //in microseconds. 15 Minutes for blink start
 const int standbyBlinkInterval = 10*1000*1000;      // microseconds between blink
+const int LAMP_BLINK_PAUSE = 400;                        // ms pause between lamp sequence blinks
 
 /*
 * VARIABLES 
 */
+static int preBlinkLEDState = LAMP_OFF;
+static bool shouldRestoreLED = false;
+static unsigned long blinkRestoreTime = 0;
 int LED_State = LAMP_OFF;
 int lastStandbyBlinkTime = 0; //The timestamp(ms) when we last blinked for standby-warning.
 
@@ -35,8 +39,9 @@ void setLEDState(int state);
 
 
 void turnLampOn(){setLEDState(LAMP_MAX);}
-void turnLampOff(){
-  setLEDState(LED_State);//Use previous
+void turnLampOff() {
+  // Turn lamp off for blinking without changing LED_State
+  setLEDState(LAMP_OFF);
 }
 
 Blinker lampBlinker = Blinker(turnLampOn, turnLampOff);
@@ -45,7 +50,7 @@ long lampDuration(char c){
   return (c == '1') ? 200 : 600;
 }
 
-BlinkSequence lampSequence = BlinkSequence(lampBlinker, lampDuration, 400);
+BlinkSequence lampSequence = BlinkSequence(lampBlinker, lampDuration, LAMP_BLINK_PAUSE);
 
 void ledLampSetup(){
     // Initialize LED PWM
@@ -57,6 +62,14 @@ void ledLampSetup(){
 void ledLampLoop(){
   lampSequence.loop();
   lampBlinker.loop();
+  // Restore LED state after blink sequence
+  if (shouldRestoreLED && millis() >= blinkRestoreTime) {
+    // Restore previous state and update LED and bar
+    LED_State = preBlinkLEDState;
+    setLEDState(LED_State);
+    setBarLED(LED_State);
+    shouldRestoreLED = false;
+  }
 }
 
 void flash(){
@@ -103,6 +116,18 @@ void setLEDState(int state) {
 }
 
 void blinkLED(const String& sequence) {
+  // If LED was on before blinking, save state and turn off
+  if (LED_State != LAMP_OFF) {
+    preBlinkLEDState = LED_State;
+    shouldRestoreLED = true;
+    // calculate total time for the blink sequence
+    unsigned long totalTime = 0;
+    for (unsigned int i = 0; i < sequence.length(); ++i) {
+      totalTime += lampDuration(sequence.charAt(i)) + LAMP_BLINK_PAUSE;
+    }
+    blinkRestoreTime = millis() + totalTime;
+    turnLampOff();
+  }
   lampSequence.blink(sequence);
 }
 

--- a/DPVController/ledLamp.cpp
+++ b/DPVController/ledLamp.cpp
@@ -73,6 +73,13 @@ void ledLampLoop(){
 }
 
 void flash(){
+  // If LED was on before flashing, save state and turn off
+  if (LED_State != LAMP_OFF) {
+    preBlinkLEDState = LED_State;
+    shouldRestoreLED = true;
+    blinkRestoreTime = millis() + 1000; // 1000ms flash duration
+    turnLampOff();
+  }
   lampBlinker.blink(1000);
 }
 


### PR DESCRIPTION
This PR enhances blinkLED so that if the lamp is already on, its brightness is saved, the lamp is turned off to run the blink sequence, and then the original brightness is restored afterward.

Changes:
- Updated turnLampOff to correctly turn off the lamp without modifying state.
- Expanded ledLampLoop to check for completion of blink sequence and restore state.
- Modified blinkLED to schedule state restoration after blink duration.

Closes #48