### PR TITLE
Use GitHub Secret for Telegram Token

### DIFF
--- a/.github/workflows/message.yml
+++ b/.github/workflows/message.yml
@@ -10,7 +10,7 @@ jobs:
         uses: appleboy/telegram-action@master
         with:
           to: '867157282'
-          token: '6537507607:AAFj5Zf9Q1NDR_K4LdXq_69BSDQjti2xkhY'
+          token: ${{ secrets.TELEGRAM_TOKEN }}
           message: |
             ${{ github.actor }} created commit:
             Commit message: ${{ github.event.commits[0].message }}


### PR DESCRIPTION
This PR replaces the hard-coded Telegram bot token in .github/workflows/message.yml with the TELEGRAM_TOKEN secret. Please add this secret in the repository settings under Settings -> Secrets -> Actions.