### PR TITLE
ci: simplify workflow to Arduino compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,10 @@ jobs:
       - name: Compile Arduino sketches
         uses: arduino/compile-sketches@v1
         with:
-          board: esp32:esp32:esp32dev
-          sketches: |
-            DPVController/DPVController.ino
-            DPVController/button.ino
+          fqbn: esp32:esp32:esp32dev
+          platforms: |
+            - esp32:esp32
+          sketch-paths: |
+            - DPVController
 
-  esp-idf-build:
-    name: ESP-IDF Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build with ESP-IDF
-        uses: espressif/esp-idf-ci-action@v1
-        with:
-          esp_idf_version: v4.4
-          target: esp32
-          path: DPVController
+


### PR DESCRIPTION
This PR removes the failing ESP-IDF build job from the CI, leaving only the Arduino compilation. The repo does not currently include an ESP-IDF project configuration (CMakeLists.txt), so this ensures CI runs successfully.