### PR TITLE
Add makefile to centralize build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# DPVControl Makefile
+# Unified command interface for building and testing
+
+# Detect platform
+ifeq ($(OS),Windows_NT)
+       PYTHON=python
+else
+       PYTHON=python3
+endif
+
+PIP=$(PYTHON) -m pip
+PIO=$(PYTHON) -m platformio
+
+.DEFAULT_GOAL := help
+
+.PHONY: help install test build clean upload
+
+help:
+	@echo "DPVControl Makefile"
+	@echo "Available targets:"
+	@echo "  install  - Install Python dependencies and PlatformIO"
+	@echo "  test     - Run unit tests"
+	@echo "  build    - Build firmware"
+	@echo "  upload   - Upload firmware to ESP32"
+	@echo "  clean    - Remove build artifacts"
+
+install:
+	$(PIP) install --upgrade pip
+	$(PIP) install --upgrade platformio requests
+
+test:
+	$(PIO) test -e native
+
+build:
+	$(PIO) run -e esp32dev
+
+upload:
+	$(PIO) run -e esp32dev -t upload
+
+clean:
+	$(PIO) run -e esp32dev -t clean

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ All required libraries are automatically managed through `platformio.ini`:
 
 No manual library installation required!
 
+### Makefile Usage
+
+For a quick command-line workflow, a `Makefile` is provided.  The most common
+tasks can be run with:
+
+```bash
+make install   # install PlatformIO and Python dependencies
+make test      # run unit tests
+make build     # build the firmware
+make upload    # upload firmware to the ESP32
+```
+
+Use `make` without arguments to list all available targets.
+
 
 # API Documentation
 


### PR DESCRIPTION
## Summary
- add a cross-platform `Makefile` with helper targets for install/test/build/upload
- document the new make commands in the README
- refine Makefile to use `python -m pip` and `python -m platformio` for portability

## Testing
- `make test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68483083f6a4832bbcdf2d2be02d9748

https://github.com/BubTec/DPVControl/issues/73