### PR TITLE
Add helpful make targets and integrate into CI

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -36,9 +36,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Python dependencies
-        run: pip install requests
-
       - name: Cache PlatformIO
         uses: actions/cache@v4
         with:
@@ -47,11 +44,11 @@ jobs:
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
 
-      - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+      - name: Install dependencies
+        run: make install
 
       - name: Build PlatformIO Project
-        run: pio run -e esp32dev
+        run: make build
 
       - name: Verify Build Artifacts
         run: |
@@ -69,7 +66,7 @@ jobs:
           fi
 
       - name: Run Unit Tests
-        run: pio test -e native
+        run: make test
 
       - name: Determine and increment version
         id: version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# DPVControl Makefile
+# Unified command interface for building and testing
+
+ifeq ($(OS),Windows_NT)
+       PYTHON=python
+       POWERSHELL=powershell
+       HOOK_CMD=$(POWERSHELL) -NoProfile -ExecutionPolicy Bypass -File create_pre_commit_hook.ps1
+else
+       PYTHON=python3
+       POWERSHELL=pwsh
+       HOOK_CMD=bash ./create_pre_commit_hook.sh
+endif
+
+PIP=$(PYTHON) -m pip
+PIO=$(PYTHON) -m platformio
+
+.DEFAULT_GOAL := help
+
+.PHONY: help install test build upload clean hook
+
+help:
+	@echo "DPVControl Makefile"
+	@echo "Available targets:"
+	@echo "  install  - Install Python dependencies and PlatformIO"
+	@echo "  test     - Run unit tests"
+	@echo "  build    - Build firmware"
+	@echo "  upload   - Upload firmware to ESP32"
+	@echo "  clean    - Remove build artifacts"
+	@echo "  hook     - Install Git pre-commit hook"
+
+install:
+	$(PIP) install --upgrade pip
+	$(PIP) install --upgrade platformio requests
+
+test:
+	$(PIO) test -e native
+
+build:
+	$(PIO) run -e esp32dev
+
+upload:
+	$(PIO) run -e esp32dev -t upload
+
+clean:
+	$(PIO) run -e esp32dev -t clean
+
+hook:
+	$(HOOK_CMD)

--- a/README.md
+++ b/README.md
@@ -46,28 +46,11 @@ This project uses **PlatformIO** for development, which provides better dependen
 
 ### Pre-commit Hook for Automated Testing
 
-To ensure code quality, a pre-commit hook is provided that automatically runs all tests before each commit. This prevents commits if any test fails.
+To ensure code quality, a pre-commit hook automatically runs all tests before each commit.
 
-**Installation:**
-1. Make sure the file `pre-commit.ps1` is located in the project root (it is versioned).
-2. In the `.git/hooks/` directory, create a file named `pre-commit.bat` with the following content:
-   ```bat
-   @echo off
-   REM pre-commit hook: runs all PlatformIO tests and prevents commit on failure
-   echo Running all tests before commit...
-   python -m platformio test -e native
-   if errorlevel 1 (
-       echo.
-       echo ERROR: Some tests failed. Commit aborted!
-       exit /b 1
-   )
-   echo All tests passed. Commit allowed.
-   exit /b 0
-   ```
-3. From now on, all tests will be run automatically before each commit. The commit will be aborted if any test fails.
+**Installation:** Run `make hook` once. On Windows this uses PowerShell, while on Linux it invokes a small shell script. Either way, a pre-commit hook is placed in `.git/hooks/` that calls the bundled `pre-commit.ps1`.
 
-> **Note:**
-> The pre-commit hook only works if you commit from the terminal (CMD). Many GUIs like GitHub Desktop or VSCode-Git do not execute local hooks or do not support batch/shell scripts as hooks.
+> **Note:** The hook only executes when committing from the command line.
 
 ### Dependencies
 All required libraries are automatically managed through `platformio.ini`:
@@ -76,6 +59,24 @@ All required libraries are automatically managed through `platformio.ini`:
 - VescUart, ClickButton, Uptime Library
 
 No manual library installation required!
+
+### Makefile Usage
+
+For a quick command-line workflow, a `Makefile` is provided.  The most common
+tasks can be run with:
+
+```bash
+make install   # install PlatformIO and Python dependencies
+make test      # run unit tests
+make build     # build the firmware
+make upload    # upload firmware to the ESP32
+```
+
+Use `make` without arguments to list all available targets.
+
+> **Windows users:** The Makefile relies on `g++` which isn't included by
+> default. Install [Cygwin](https://cygwin.com) with the `g++` package and
+> ensure the Cygwin `bin` directory is on your `PATH` to use these commands.
 
 
 # API Documentation

--- a/create_pre_commit_hook.sh
+++ b/create_pre_commit_hook.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Script to create a Git pre-commit hook on Unix-like systems
+HOOK_PATH=".git/hooks/pre-commit"
+cat > "$HOOK_PATH" <<'HOOK'
+#!/usr/bin/env bash
+pwsh -NoProfile -ExecutionPolicy Bypass -File "$(git rev-parse --show-toplevel)/pre-commit.ps1"
+HOOK
+chmod +x "$HOOK_PATH"
+echo "pre-commit hook created at $HOOK_PATH"


### PR DESCRIPTION
## Summary
- refine the Makefile with a new `HOOK_CMD` for cross-platform hook creation
- add `create_pre_commit_hook.sh` for Linux/Unix pre-commit hook installation
- clarify cross-platform usage in the README

## Testing
- `make install`
- `make test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68483083f6a4832bbcdf2d2be02d9748