### PR TITLE
Add Ubuntu/Linux support for development workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ check-cppcheck-build-dir
 # Local configuration file for DPVController
 DPVController/localConfig.h
 
+# Python virtual environment
+.venv/
+
 # PlatformIO directories
 .pio/
 .pioenvs/

--- a/Makefile
+++ b/Makefile
@@ -20,17 +20,18 @@ endif
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install venv test build clean upload
+.PHONY: help install venv test build clean upload hook
 
 help:
 	@echo "DPVControl Makefile"
 	@echo "Available targets:"
-	@echo "  install  - Install Python dependencies and PlatformIO"
+	@echo "  install  - Install Python dependencies, PlatformIO, and pre-commit hook"
 	@echo "  venv     - Create Python virtual environment (Linux/macOS)"
 	@echo "  test     - Run unit tests"
 	@echo "  build    - Build firmware"
 	@echo "  upload   - Upload firmware to ESP32"
 	@echo "  clean    - Remove build artifacts"
+	@echo "  hook     - Install git pre-commit hook"
 
 # Create venv (Linux/macOS only, no-op on Windows)
 venv:
@@ -46,9 +47,24 @@ else
 	fi
 endif
 
-install: venv
+install: venv hook
 	$(PIP) install --upgrade pip
 	$(PIP) install --upgrade platformio requests
+
+# Install git pre-commit hook that runs tests before each commit
+hook:
+	@if [ -d ".git" ]; then \
+		mkdir -p .git/hooks; \
+		if [ "$(OS)" = "Windows_NT" ]; then \
+			printf '@echo off\r\necho Running all tests before commit...\r\npython -m platformio test -e native\r\nif errorlevel 1 (\r\n    echo.\r\n    echo ERROR: Some tests failed. Commit aborted!\r\n    exit /b 1\r\n)\r\necho All tests passed. Commit allowed.\r\nexit /b 0\r\n' > .git/hooks/pre-commit; \
+		else \
+			printf '#!/usr/bin/env bash\nset -e\n\nSCRIPT_DIR="$$(cd "$$(dirname "$$0")/../.." && pwd)"\nif [ -f "$$SCRIPT_DIR/.venv/bin/activate" ]; then\n    . "$$SCRIPT_DIR/.venv/bin/activate"\nfi\n\necho "Running all tests before commit..."\npython3 -m platformio test -e native\necho "All tests passed. Commit allowed."\n' > .git/hooks/pre-commit; \
+			chmod +x .git/hooks/pre-commit; \
+		fi; \
+		echo "Pre-commit hook installed."; \
+	else \
+		echo "Not a git repository — skipping hook installation."; \
+	fi
 
 test:
 	$(PIO) test -e native

--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,49 @@
 # Detect platform
 ifeq ($(OS),Windows_NT)
        PYTHON=python
+       PIP=$(PYTHON) -m pip
+       PIO=$(PYTHON) -m platformio
 else
-       PYTHON=python3
+       # On Linux/macOS, use the venv if it exists
+       VENV_DIR=.venv
+       ifneq ($(wildcard $(VENV_DIR)/bin/python3),)
+              PYTHON=$(VENV_DIR)/bin/python3
+       else
+              PYTHON=python3
+       endif
+       PIP=$(PYTHON) -m pip
+       PIO=$(PYTHON) -m platformio
 endif
-
-PIP=$(PYTHON) -m pip
-PIO=$(PYTHON) -m platformio
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install test build clean upload
+.PHONY: help install venv test build clean upload
 
 help:
 	@echo "DPVControl Makefile"
 	@echo "Available targets:"
 	@echo "  install  - Install Python dependencies and PlatformIO"
+	@echo "  venv     - Create Python virtual environment (Linux/macOS)"
 	@echo "  test     - Run unit tests"
 	@echo "  build    - Build firmware"
 	@echo "  upload   - Upload firmware to ESP32"
 	@echo "  clean    - Remove build artifacts"
 
-install:
+# Create venv (Linux/macOS only, no-op on Windows)
+venv:
+ifeq ($(OS),Windows_NT)
+	@echo "Virtual environment not needed on Windows (use pip directly)."
+else
+	@if [ ! -d "$(VENV_DIR)" ]; then \
+		echo "Creating virtual environment in $(VENV_DIR)..."; \
+		python3 -m venv $(VENV_DIR); \
+		echo "Virtual environment created. Run 'make install' next."; \
+	else \
+		echo "Virtual environment already exists."; \
+	fi
+endif
+
+install: venv
 	$(PIP) install --upgrade pip
 	$(PIP) install --upgrade platformio requests
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@ I would greatly appreciate support for my project. Every $ contributes to enhanc
 
 # Development
 
-## PlatformIO with VS Code
+## PlatformIO with VS Code (all platforms)
 This project uses **PlatformIO** for development, which provides better dependency management and build system compared to the Arduino IDE.
-
-### Setup Instructions (Windows)
 
 1. **Install VS Code**: Download from [code.visualstudio.com](https://code.visualstudio.com/)
 
@@ -46,61 +44,40 @@ This project uses **PlatformIO** for development, which provides better dependen
    - Click "Upload" (→) to flash to ESP32
    - Click "Serial Monitor" to view debug output
 
-### Setup Instructions (Ubuntu / Linux)
+## Command-Line Setup
 
-1. **Install system dependencies**:
-   ```bash
-   sudo apt update
-   sudo apt install python3 python3-venv git
-   ```
+If you prefer working from the terminal, or need to run tests in CI, use the Makefile workflow below.
 
-2. **Clone and set up the project**:
-   ```bash
-   git clone https://github.com/BubTec/DPVControl.git
-   cd DPVControl
-   ```
+### Linux / macOS
 
-3. **Create a Python virtual environment and install PlatformIO**:
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
-   pip install --upgrade pip platformio requests
-   ```
-
-4. **Run unit tests**:
-   ```bash
-   source .venv/bin/activate
-   pio test -e native
-   ```
-
-5. **Build firmware**:
-   ```bash
-   source .venv/bin/activate
-   pio run -e esp32dev
-   ```
-
-6. **Upload firmware** (with ESP32 connected via USB):
-   ```bash
-   source .venv/bin/activate
-   pio run -e esp32dev -t upload
-   ```
-
-> **Tip:** You can also use VS Code with the PlatformIO extension on Linux — install it the same way as on Windows. The venv-based CLI setup above is an alternative that works without an IDE.
-
-### Pre-commit Hook for Automated Testing
-
-To ensure code quality, a pre-commit hook is provided that automatically runs all tests before each commit. This prevents commits if any test fails.
-
-The hook is installed automatically as part of `make install`, or you can install it separately:
-
+Install system dependencies first:
 ```bash
-make hook
+sudo apt update
+sudo apt install python3 python3-venv git   # Debian/Ubuntu
 ```
 
-This works on both Windows and Linux/macOS — the Makefile generates the appropriate hook script for your platform.
+Then set up the project:
+```bash
+git clone https://github.com/BubTec/DPVControl.git
+cd DPVControl
+make install   # creates .venv, installs PlatformIO, sets up pre-commit hook
+make test      # run unit tests
+make build     # build the firmware
+make upload    # upload firmware to the ESP32
+```
 
-> **Note:**
-> The pre-commit hook only works if you commit from the terminal. Many GUIs like GitHub Desktop do not execute local hooks.
+### Windows
+
+```cmd
+git clone https://github.com/BubTec/DPVControl.git
+cd DPVControl
+make install   # installs PlatformIO, sets up pre-commit hook
+make test      # run unit tests
+make build     # build the firmware
+make upload    # upload firmware to the ESP32
+```
+
+Use `make` without arguments to list all available targets.
 
 ### Dependencies
 All required libraries are automatically managed through `platformio.ini`:
@@ -110,22 +87,11 @@ All required libraries are automatically managed through `platformio.ini`:
 
 No manual library installation required!
 
-### Makefile Usage
+### Pre-commit Hook
 
-For a quick command-line workflow, a `Makefile` is provided.  The most common
-tasks can be run with:
+A pre-commit hook that runs all tests before each commit is installed automatically by `make install`. You can also install it separately with `make hook`.
 
-```bash
-# On Linux, activate the venv first:
-source .venv/bin/activate
-
-make install   # install PlatformIO and Python dependencies
-make test      # run unit tests
-make build     # build the firmware
-make upload    # upload firmware to the ESP32
-```
-
-Use `make` without arguments to list all available targets.
+> **Note:** The hook only works when committing from the terminal. Many GUIs like GitHub Desktop do not execute local hooks.
 
 
 # API Documentation

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ I would greatly appreciate support for my project. Every $ contributes to enhanc
 ## PlatformIO with VS Code
 This project uses **PlatformIO** for development, which provides better dependency management and build system compared to the Arduino IDE.
 
-### Setup Instructions
+### Setup Instructions (Windows)
 
 1. **Install VS Code**: Download from [code.visualstudio.com](https://code.visualstudio.com/)
 
@@ -46,11 +46,54 @@ This project uses **PlatformIO** for development, which provides better dependen
    - Click "Upload" (→) to flash to ESP32
    - Click "Serial Monitor" to view debug output
 
+### Setup Instructions (Ubuntu / Linux)
+
+1. **Install system dependencies**:
+   ```bash
+   sudo apt update
+   sudo apt install python3 python3-venv git
+   ```
+
+2. **Clone and set up the project**:
+   ```bash
+   git clone https://github.com/BubTec/DPVControl.git
+   cd DPVControl
+   ```
+
+3. **Create a Python virtual environment and install PlatformIO**:
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip platformio requests
+   ```
+
+4. **Run unit tests**:
+   ```bash
+   source .venv/bin/activate
+   pio test -e native
+   ```
+
+5. **Build firmware**:
+   ```bash
+   source .venv/bin/activate
+   pio run -e esp32dev
+   ```
+
+6. **Upload firmware** (with ESP32 connected via USB):
+   ```bash
+   source .venv/bin/activate
+   pio run -e esp32dev -t upload
+   ```
+
+> **Tip:** You can also use VS Code with the PlatformIO extension on Linux — install it the same way as on Windows. The venv-based CLI setup above is an alternative that works without an IDE.
+
 ### Pre-commit Hook for Automated Testing
 
 To ensure code quality, a pre-commit hook is provided that automatically runs all tests before each commit. This prevents commits if any test fails.
 
-**Installation:**
+<details>
+<summary><strong>Windows (CMD / PowerShell)</strong></summary>
+
 1. Make sure the file `pre-commit.ps1` is located in the project root (it is versioned).
 2. In the `.git/hooks/` directory, create a file named `pre-commit.bat` with the following content:
    ```bat
@@ -66,10 +109,37 @@ To ensure code quality, a pre-commit hook is provided that automatically runs al
    echo All tests passed. Commit allowed.
    exit /b 0
    ```
-3. From now on, all tests will be run automatically before each commit. The commit will be aborted if any test fails.
 
 > **Note:**
 > The pre-commit hook only works if you commit from the terminal (CMD). Many GUIs like GitHub Desktop or VSCode-Git do not execute local hooks or do not support batch/shell scripts as hooks.
+
+</details>
+
+<details>
+<summary><strong>Linux / macOS</strong></summary>
+
+Create the file `.git/hooks/pre-commit` with the following content and make it executable:
+```bash
+#!/usr/bin/env bash
+set -e
+
+# Activate venv if present
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+if [ -f "$SCRIPT_DIR/.venv/bin/activate" ]; then
+    source "$SCRIPT_DIR/.venv/bin/activate"
+fi
+
+echo "Running all tests before commit..."
+python3 -m platformio test -e native
+echo "All tests passed. Commit allowed."
+```
+
+Then run:
+```bash
+chmod +x .git/hooks/pre-commit
+```
+
+</details>
 
 ### Dependencies
 All required libraries are automatically managed through `platformio.ini`:
@@ -85,6 +155,9 @@ For a quick command-line workflow, a `Makefile` is provided.  The most common
 tasks can be run with:
 
 ```bash
+# On Linux, activate the venv first:
+source .venv/bin/activate
+
 make install   # install PlatformIO and Python dependencies
 make test      # run unit tests
 make build     # build the firmware

--- a/README.md
+++ b/README.md
@@ -91,55 +91,16 @@ This project uses **PlatformIO** for development, which provides better dependen
 
 To ensure code quality, a pre-commit hook is provided that automatically runs all tests before each commit. This prevents commits if any test fails.
 
-<details>
-<summary><strong>Windows (CMD / PowerShell)</strong></summary>
+The hook is installed automatically as part of `make install`, or you can install it separately:
 
-1. Make sure the file `pre-commit.ps1` is located in the project root (it is versioned).
-2. In the `.git/hooks/` directory, create a file named `pre-commit.bat` with the following content:
-   ```bat
-   @echo off
-   REM pre-commit hook: runs all PlatformIO tests and prevents commit on failure
-   echo Running all tests before commit...
-   python -m platformio test -e native
-   if errorlevel 1 (
-       echo.
-       echo ERROR: Some tests failed. Commit aborted!
-       exit /b 1
-   )
-   echo All tests passed. Commit allowed.
-   exit /b 0
-   ```
+```bash
+make hook
+```
+
+This works on both Windows and Linux/macOS — the Makefile generates the appropriate hook script for your platform.
 
 > **Note:**
-> The pre-commit hook only works if you commit from the terminal (CMD). Many GUIs like GitHub Desktop or VSCode-Git do not execute local hooks or do not support batch/shell scripts as hooks.
-
-</details>
-
-<details>
-<summary><strong>Linux / macOS</strong></summary>
-
-Create the file `.git/hooks/pre-commit` with the following content and make it executable:
-```bash
-#!/usr/bin/env bash
-set -e
-
-# Activate venv if present
-SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-if [ -f "$SCRIPT_DIR/.venv/bin/activate" ]; then
-    source "$SCRIPT_DIR/.venv/bin/activate"
-fi
-
-echo "Running all tests before commit..."
-python3 -m platformio test -e native
-echo "All tests passed. Commit allowed."
-```
-
-Then run:
-```bash
-chmod +x .git/hooks/pre-commit
-```
-
-</details>
+> The pre-commit hook only works if you commit from the terminal. Many GUIs like GitHub Desktop do not execute local hooks.
 
 ### Dependencies
 All required libraries are automatically managed through `platformio.ini`:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ I would greatly appreciate support for my project. Every $ contributes to enhanc
 
 # Development
 
-## PlatformIO with VS Code (all platforms)
+## PlatformIO with VS Code
+
 This project uses **PlatformIO** for development, which provides better dependency management and build system compared to the Arduino IDE.
 
 1. **Install VS Code**: Download from [code.visualstudio.com](https://code.visualstudio.com/)
@@ -55,23 +56,13 @@ Install system dependencies first:
 sudo apt update
 sudo apt install python3 python3-venv git   # Debian/Ubuntu
 ```
+### Run make
 
 Then set up the project:
 ```bash
 git clone https://github.com/BubTec/DPVControl.git
 cd DPVControl
 make install   # creates .venv, installs PlatformIO, sets up pre-commit hook
-make test      # run unit tests
-make build     # build the firmware
-make upload    # upload firmware to the ESP32
-```
-
-### Windows
-
-```cmd
-git clone https://github.com/BubTec/DPVControl.git
-cd DPVControl
-make install   # installs PlatformIO, sets up pre-commit hook
 make test      # run unit tests
 make build     # build the firmware
 make upload    # upload firmware to the ESP32


### PR DESCRIPTION
## Summary

Adds Linux/Ubuntu support so the project can be developed on both Windows and Linux machines.

## What changed

| File | Change |
|------|--------|
| `.gitignore` | Added `.venv/` |
| `Makefile` | Auto-detects and uses `.venv` on Linux; added `make venv` target |
| `README.md` | Added full Linux setup instructions + bash pre-commit hook |

## No source code changes

The C++ code and PlatformIO config were already cross-platform. Both the native unit tests (12/12 passed) and the ESP32 firmware build succeed on Ubuntu without modifications.

## Linux quick start

```bash
sudo apt install python3 python3-venv git
git clone https://github.com/BubTec/DPVControl.git
cd DPVControl
make install   # creates venv + installs PlatformIO
make test      # runs all unit tests
make build     # builds ESP32 firmware
```